### PR TITLE
`FM-Rest`インストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,14 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '3.2.1'
 
 gem 'bootsnap', require: false
+gem 'fmrest'
+gem 'fmrest-cloud'
 gem 'importmap-rails'
 gem 'jbuilder'
 gem 'puma', '~> 5.0'
 gem 'rack-cors'
 gem 'rails', '7.0.4.3'
+gem 'redis'
 gem 'sidekiq'
 gem 'sprockets-rails'
 gem 'stimulus-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,20 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    aws-cognito-srp (0.5.0)
+      aws-sdk-cognitoidentityprovider
+    aws-eventstream (1.2.0)
+    aws-partitions (1.738.0)
+    aws-sdk-cognitoidentityprovider (1.73.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-core (3.171.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -95,6 +109,27 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faraday (2.7.4)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (3.0.2)
+    fmrest (0.24.0)
+      fmrest-core (= 0.24.0)
+      fmrest-rails (= 0.24.0)
+      fmrest-spyke (= 0.24.0)
+    fmrest-cloud (0.24.0)
+      aws-cognito-srp (>= 0.4.0)
+      fmrest-core (= 0.24.0)
+    fmrest-core (0.24.0)
+      faraday (>= 2.0)
+      faraday-multipart
+    fmrest-rails (0.24.0)
+      fmrest-core (= 0.24.0)
+    fmrest-spyke (0.24.0)
+      fmrest-core (= 0.24.0)
+      spyke (>= 7.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -105,6 +140,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     json (2.6.3)
     loofah (2.19.1)
       crass (~> 1.0.2)
@@ -120,6 +156,7 @@ GEM
     mini_mime (1.1.2)
     minitest (5.18.0)
     msgpack (1.6.1)
+    multipart-post (2.3.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -177,6 +214,8 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redis (5.0.6)
+      redis-client (>= 0.9.0)
     redis-client (0.14.1)
       connection_pool
     regexp_parser (2.7.0)
@@ -211,6 +250,7 @@ GEM
     rubocop-ast (1.28.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.8.2)
       rexml (~> 3.2, >= 3.2.5)
@@ -228,6 +268,12 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    spyke (7.0.0)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
+      addressable (>= 2.5.2)
+      faraday (>= 1.0.0, < 3.0)
+      faraday-multipart (~> 1.0)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     thor (1.2.1)
@@ -264,12 +310,15 @@ DEPENDENCIES
   capybara
   debug
   factory_bot_rails
+  fmrest
+  fmrest-cloud
   importmap-rails
   jbuilder
   pry-rails
   puma (~> 5.0)
   rack-cors
   rails (= 7.0.4.3)
+  redis
   rspec-rails
   rubocop
   selenium-webdriver

--- a/app/controllers/api/v1/tests_controller.rb
+++ b/app/controllers/api/v1/tests_controller.rb
@@ -3,11 +3,15 @@
 class Api::V1::TestsController < Api::V1::ApplicationController
   def index
     #  curl "http://localhost:8000/api/v1/tests"
-    render json: { status: :ok, message: 'test' }
+    tdm = TestDtbMitsumori.new(name: 'from Rails!!!')
+    res = tdm.save
+    render json: { status: :ok, message: res }
   end
 
   def create
-    # curl -X POST -H 'Content-Type: application/json' -d '{"hoge": "fuga"}' "http://localhost:8000/api/v1/tests"
+    # curl -X POST -H 'Content-Type: application/json' -d '{"name": "fuga"}' "http://localhost:8000/api/v1/tests"
+    tdm = TestDtbMitsumori.new(name: params[:name]) # 本来はストロングパラメータ使ってね
+    res = tdm.save
     render json: { status: :ok, message: "You send params: #{params.to_json}" }
   end
 end

--- a/app/models/test_dtb_mitsumori.rb
+++ b/app/models/test_dtb_mitsumori.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class TestDtbMitsumori < FmRest::Layout('test_dtb_mitsumori') # 引数でlayout名を指定
+  attributes name: 'name' # キーとカラムをマッピングできる
+end

--- a/config/fmrest.yml
+++ b/config/fmrest.yml
@@ -1,0 +1,18 @@
+development:
+  host: 
+  database: 
+  username: 
+  password: 
+
+  # Additional options
+  #
+  # log: false
+  #
+  # ssl:
+  #   verify: true
+
+test:
+  host: 
+  database: 
+  username: 
+  password: 

--- a/config/initializers/fmrest.rb
+++ b/config/initializers/fmrest.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Use ActiveRecord token store
+# FmRest.token_store = FmRest::TokenStore::ActiveRecord
+
+# Use ActiveRecord token store with custom table name
+# FmRest.token_store = FmRest::TokenStore::ActiveRecord.new(table_name: "my_token_store")
+
+# Use Redis token store (requires redis gem)
+host = ENV.fetch('REDIS_HOST', nil)
+port = ENV.fetch('REDIS_PORT', nil)
+TOKEN_STORE_DB = 8
+token_store_url = "redis://#{host}:#{port}/#{TOKEN_STORE_DB}"
+FmRest.token_store = FmRest::TokenStore::Redis.new(url: token_store_url)
+
+# Use Redis token store with custom prefix
+# FmRest.token_store = FmRest::TokenStore::Redis.new(prefix: "my-fmrest-token:")
+
+# Use Moneta token store (requires moneta gem)
+# FmRest.token_store = FmRest::TokenStore::Moneta.new(backend: )
+
+# Use Memory token store (not suitable for production)
+# FmRest.token_store = FmRest::TokenStore::Memory
+
+FmRest.default_connection_settings = {
+  host: ENV.fetch('FILEMAKER_HOST', nil),
+  database: ENV.fetch('FILEMAKER_DB', nil),
+  username: ENV.fetch('CLARIS_ID', nil),
+  password: ENV.fetch('CLARIS_PASS', nil)
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ x-template: &rails
   environment:
     REDIS_HOST: $REDIS_HOST
     REDIS_PORT: $REDIS_PORT
+    FILEMAKER_HOST:  $FILEMAKER_HOST
+    FILEMAKER_DB: $FILEMAKER_DB
+    CLARIS_ID: $CLARIS_ID
+    CLARIS_PASS: $CLARIS_PASS
 
 services:
   web:


### PR DESCRIPTION
FilemakerをRESTに使えるらしい[Gem fmrest](https://github.com/beezwax/fmrest-ruby)をインストールしました。

## できるようになった
`curl -X POST -H 'Content-Type: application/json' -d '{"name": "fuga"}' "http://localhost:8000/api/v1/tests"`
とリクエスト飛ばせば、
FMDBの`test_dtb_mitsumori`に `name: hoge` というレコードができる

## 環境変数の用意とClarisIDの設定
.envに以下のように追記してください
```
export FILEMAKER_HOST=hogehoge.account.filemaker-cloud.com # hogehogeの部分を変える
export FILEMAKER_DB=DB名                                      # DB名を入れるカッコは全角で、スペースは半角で
export CLARIS_ID=hogehoge@gmail.com                         # ClarisのログインID
export CLARIS_PASS=password　　　　　　　　　　　　 # ClarisのログインPW
```
**Clarisログイン時の２段階認証をOFFにしてください**
https://console.claris.com/app/home ここの右上のユーザープロファイルから設定変更できます