### PR TITLE
boseki-info からFMの送客管理テーブルに保存できるエンドポイントを作成

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,6 @@ Metrics/MethodLength:
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*"
+
+Layout/LineLength:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,7 @@ Metrics/MethodLength:
   Max: 20
   Exclude:
     - "db/migrate/*.rb"
+    
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,9 @@ Metrics/BlockLength:
 
 Layout/LineLength:
   Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::ApplicationController < ApplicationController
   private
 
   def basic_auth
-    return unless ENV.fetch('BASIC_USER', nil) || ENV.fetch('BASIC_PASS', nil)
+    return unless ENV.fetch('BASIC_USER', nil).nil? || ENV.fetch('BASIC_PASS', nil).nil?
 
     authenticate_or_request_with_http_basic do |username, password|
       username == ENV.fetch('BASIC_USER', nil) && password == ENV.fetch('BASIC_PASS', nil)

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -2,4 +2,15 @@
 
 class Api::V1::ApplicationController < ApplicationController
   skip_before_action :verify_authenticity_token
+  before_action :basic_auth
+
+  private
+
+  def basic_auth
+    return unless ENV.fetch('BASIC_USER', nil) || ENV.fetch('BASIC_PASS', nil)
+
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV.fetch('BASIC_USER', nil) && password == ENV.fetch('BASIC_PASS', nil)
+    end
+  end
 end

--- a/app/controllers/api/v1/boseki_infos_controller.rb
+++ b/app/controllers/api/v1/boseki_infos_controller.rb
@@ -18,24 +18,15 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
     render json: { status: 500, error: "Failure: #{e}" }
   end
 
-  # rubocop:disable Metrics/AbcSize
   def update
     # curl -X PATCH -H 'Content-Type: application/json' -d '{"data": {"record_id": "245444", "cemetery_name": "本能寺" }}' "http://localhost:8000/api/v1/boseki_info"
     data = Soukyakukanri.find(boseki_info_params[:record_id])
-    data.update(
-      cemetery_name: boseki_info_params[:cemetery_name] || data.cemetery_name,
-      cemetery_addr: boseki_info_params[:cemetery_addr] || data.cemetery_addr,
-      contact_time: boseki_info_params[:addr] || data.contact_time,
-      contact_note: boseki_info_params[:area] || data.contact_note,
-      customer_request: boseki_info_params[:mitsumori] || data.customer_request,
-      email: boseki_info_params[:email] || data.email
-    )
+    data.update(update_params(data))
     render json: { status: :ok, record_id: data.record_id }
   rescue StandardError => e
     Rails.logger.error e
     render json: { status: 500, error: "Failure: #{e}" }
   end
-  # rubocop:enable Metrics/AbcSize
 
   private
 
@@ -43,4 +34,17 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
     params.require(:data).permit(:record_id, :name, :tel, :work_type, :cemetery_name, :cemetery_addr, :addr, :area,
                                  :mitsumori, :email)
   end
+
+  # rubocop:disable Metrics/AbcSize
+  def update_params(data)
+    {
+      cemetery_name: boseki_info_params[:cemetery_name] || data.cemetery_name,
+      cemetery_addr: boseki_info_params[:cemetery_addr] || data.cemetery_addr,
+      contact_time: boseki_info_params[:addr] || data.contact_time,
+      contact_note: boseki_info_params[:area] || data.contact_note,
+      customer_request: boseki_info_params[:mitsumori] || data.customer_request,
+      email: boseki_info_params[:email] || data.email
+    }
+  end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/controllers/api/v1/boseki_infos_controller.rb
+++ b/app/controllers/api/v1/boseki_infos_controller.rb
@@ -5,7 +5,6 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
 
   def create
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"name": "名前", "tel": "0120123456", "work_type": "墓じまいをしたい" }}' "http://localhost:8000/api/v1/boseki_info"
-
     data = Soukyakukanri.new(
       media_name: MEDIA_NAME,
       name: boseki_info_params[:name],
@@ -14,6 +13,9 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す
+  rescue StandardError => e
+    Rails.logger.error e
+    render json: { status: 500, error: "Failure: #{e}" }
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -29,6 +31,9 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
       email: boseki_info_params[:email] || data.email
     )
     render json: { status: :ok, record_id: data.record_id }
+  rescue StandardError => e
+    Rails.logger.error e
+    render json: { status: 500, error: "Failure: #{e}" }
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/app/controllers/api/v1/boseki_infos_controller.rb
+++ b/app/controllers/api/v1/boseki_infos_controller.rb
@@ -20,6 +20,7 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
 
   def update
     # curl -X PATCH -H 'Content-Type: application/json' -d '{"data": {"record_id": "245444", "cemetery_name": "本能寺" }}' "http://localhost:8000/api/v1/boseki_info"
+    # ページ遷移するごとにキー名が変わっていきます、cemetery_name, cemetery_addr, work_date, ['addr','area'], 'mitsumori', 'email' 
     data = Soukyakukanri.find(boseki_info_params[:record_id])
     data.update(update_params(data))
     render json: { status: :ok, record_id: data.record_id }

--- a/app/controllers/api/v1/boseki_infos_controller.rb
+++ b/app/controllers/api/v1/boseki_infos_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
 
   def update
     # curl -X PATCH -H 'Content-Type: application/json' -d '{"data": {"record_id": "245444", "cemetery_name": "本能寺" }}' "http://localhost:8000/api/v1/boseki_info"
-    # ページ遷移するごとにキー名が変わっていきます、cemetery_name, cemetery_addr, work_date, ['addr','area'], 'mitsumori', 'email' 
+    # ページ遷移するごとにキー名が変わっていきます、cemetery_name, cemetery_addr, work_date, ['addr','area'], 'mitsumori', 'email'
     data = Soukyakukanri.find(boseki_info_params[:record_id])
     data.update(update_params(data))
     render json: { status: :ok, record_id: data.record_id }

--- a/app/controllers/api/v1/boseki_infos_controller.rb
+++ b/app/controllers/api/v1/boseki_infos_controller.rb
@@ -36,7 +36,6 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
                                  :mitsumori, :email)
   end
 
-  # rubocop:disable Metrics/AbcSize
   def update_params(data)
     {
       cemetery_name: boseki_info_params[:cemetery_name] || data.cemetery_name,
@@ -47,5 +46,4 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
       email: boseki_info_params[:email] || data.email
     }
   end
-  # rubocop:enable Metrics/AbcSize
 end

--- a/app/controllers/api/v1/boseki_infos_controller.rb
+++ b/app/controllers/api/v1/boseki_infos_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
     data = Soukyakukanri.new(
       media_name: MEDIA_NAME,
       name: boseki_info_params[:name],
-      tel: boseki_info_params[:tel],
+      tel1: boseki_info_params[:tel],
       work_type: boseki_info_params[:work_type]
     )
     data.save

--- a/app/controllers/api/v1/boseki_infos_controller.rb
+++ b/app/controllers/api/v1/boseki_infos_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class Api::V1::BosekiInfosController < Api::V1::ApplicationController
+  MEDIA_NAME = '墓石ナビ'
+
+  def create
+    # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"name": "名前", "tel": "0120123456", "work_type": "墓じまいをしたい" }}' "http://localhost:8000/api/v1/boseki_info"
+
+    data = Soukyakukanri.new(
+      media_name: MEDIA_NAME,
+      name: boseki_info_params[:name],
+      tel: boseki_info_params[:tel],
+      work_type: boseki_info_params[:work_type]
+    )
+    data.save
+    render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def update
+    # curl -X PATCH -H 'Content-Type: application/json' -d '{"data": {"record_id": "245444", "cemetery_name": "本能寺" }}' "http://localhost:8000/api/v1/boseki_info"
+    data = Soukyakukanri.find(boseki_info_params[:record_id])
+    data.update(
+      cemetery_name: boseki_info_params[:cemetery_name] || data.cemetery_name,
+      cemetery_addr: boseki_info_params[:cemetery_addr] || data.cemetery_addr,
+      contact_time: boseki_info_params[:addr] || data.contact_time,
+      contact_note: boseki_info_params[:area] || data.contact_note,
+      customer_request: boseki_info_params[:mitsumori] || data.customer_request,
+      email: boseki_info_params[:email] || data.email
+    )
+    render json: { status: :ok, record_id: data.record_id }
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  private
+
+  def boseki_info_params
+    params.require(:data).permit(:record_id, :name, :tel, :work_type, :cemetery_name, :cemetery_addr, :addr, :area,
+                                 :mitsumori, :email)
+  end
+end

--- a/app/models/soukyakukanri.rb
+++ b/app/models/soukyakukanri.rb
@@ -2,14 +2,14 @@
 
 class Soukyakukanri < FmRest::Layout('送客管理')
   attributes(
-    media_name: 'F.外壁／防水',
-    name: 'H氏名',
-    tel: 'K.電話番号1',
+    media_name: 'F_外壁／防水',
+    name: 'H_氏名',
+    tel1: 'K_電話番号1',
     work_date: '完成希望時期',
     contact_time: '連絡希望時間',
     contact_note: '連絡留意事項',
     customer_request: 'ご要望',
-    email: 'J.メールアドレス',
+    email: 'J_メールアドレス',
     work_type: '施工内容',
     cemetery_name: '霊園名',
     cemetery_addr: '墓所住所'

--- a/app/models/soukyakukanri.rb
+++ b/app/models/soukyakukanri.rb
@@ -3,15 +3,23 @@
 class Soukyakukanri < FmRest::Layout('送客管理')
   attributes(
     media_name: 'F_外壁／防水',
+    prefecture: 'E_都道府県',
     name: 'H_氏名',
     tel1: 'K_電話番号1',
+    building_type: '工事種別',
     work_date: '完成希望時期',
     contact_time: '連絡希望時間',
     contact_note: '連絡留意事項',
     customer_request: 'ご要望',
     email: 'J_メールアドレス',
+    area: '建物の面積',
+    floor: '建物の階数',
+    budget: '予算',
     work_type: '施工内容',
+    building_age: '建物の築年数',
     cemetery_name: '霊園名',
-    cemetery_addr: '墓所住所'
+    cemetery_addr: '墓所住所',
+    tel2: 'L_電話番号2',
+    kana: 'I_フリガナ'
   )
 end

--- a/app/models/soukyakukanri.rb
+++ b/app/models/soukyakukanri.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Soukyakukanri < FmRest::Layout('送客管理')
+  attributes(
+    media_name: 'F.外壁／防水',
+    name: 'H氏名',
+    tel: 'K.電話番号1',
+    work_date: '完成希望時期',
+    contact_time: '連絡希望時間',
+    contact_note: '連絡留意事項',
+    customer_request: 'ご要望',
+    email: 'J.メールアドレス',
+    work_type: '施工内容',
+    cemetery_name: '霊園名',
+    cemetery_addr: '墓所住所'
+  )
+end

--- a/app/models/soukyakukanri.rb
+++ b/app/models/soukyakukanri.rb
@@ -9,8 +9,8 @@ class Soukyakukanri < FmRest::Layout('送客管理')
     building_type: '建物の種類',
     construction_type: '工事種別',
     work_date: '完成希望時期',
-    contact_time: 'AA_電話確認', # 本来は[連絡希望時間]だがこの名前のフィールドが存在しないので、一旦違うものに入れてある
-    contact_note: 'X_最終架電結果', # 本来は[連絡留意事項]だがこの名前のフィールドが存在しないので、一旦違うものに入れてある
+    contact_time: '連絡希望時間',
+    contact_note: '連絡留意事項',
     customer_request: 'ご要望',
     email: 'J_メールアドレス',
     area: '建物の面積',

--- a/app/models/soukyakukanri.rb
+++ b/app/models/soukyakukanri.rb
@@ -6,10 +6,11 @@ class Soukyakukanri < FmRest::Layout('送客管理')
     prefecture: 'E_都道府県',
     name: 'H_氏名',
     tel1: 'K_電話番号1',
-    building_type: '工事種別',
+    building_type: '建物の種類',
+    construction_type: '工事種別',
     work_date: '完成希望時期',
-    contact_time: '連絡希望時間',
-    contact_note: '連絡留意事項',
+    contact_time: 'AA_電話確認', # 本来は[連絡希望時間]だがこの名前のフィールドが存在しないので、一旦違うものに入れてある
+    contact_note: 'X_最終架電結果', # 本来は[連絡留意事項]だがこの名前のフィールドが存在しないので、一旦違うものに入れてある
     customer_request: 'ご要望',
     email: 'J_メールアドレス',
     area: '建物の面積',

--- a/app/models/test_dtb_mitsumori.rb
+++ b/app/models/test_dtb_mitsumori.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class TestDtbMitsumori < FmRest::Layout('test_dtb_mitsumori') # 引数でlayout名を指定
+class TestDtbMitsumori < FmRest::Layout('test_dtb_mitsumori')
   attributes name: 'name' # キーとカラムをマッピングできる
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   namespace 'api' do
     namespace 'v1' do
       resources :tests, only: %i[index create]
+      resource :boseki_info, only: %i[create update]
     end
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ x-template: &rails
     FILEMAKER_DB: $FILEMAKER_DB
     CLARIS_ID: $CLARIS_ID
     CLARIS_PASS: $CLARIS_PASS
+    BASIC_USER: $BASIC_USER
+    BASIC_PASS: $BASIC_PASS
 
 services:
   web:

--- a/spec/factories/soukyakukanri.rb
+++ b/spec/factories/soukyakukanri.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :soukyakukanri do
+    name { '織田信長' }
+  end
+end

--- a/spec/requests/api/v1/boseki_infos_spec.rb
+++ b/spec/requests/api/v1/boseki_infos_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Api::V1::BosekiInfos', type: :request do
         }
       }
     end
-    let(:data) { create(:soukyakukanri) }
+    let(:data) { build(:soukyakukanri) }
 
     context 'FMのレコード更新成功時' do
       let(:fm_response) { { recordId: record_id } }

--- a/spec/requests/api/v1/boseki_infos_spec.rb
+++ b/spec/requests/api/v1/boseki_infos_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::BosekiInfos', type: :request do
+  describe '#create' do
+    let(:params) do
+      {
+        data: {
+          name: '織田信長',
+          tel: '012012345678',
+          work_type: '墓じまいをしたい'
+        }
+      }
+    end
+
+    context 'FMのレコード作成成功時' do
+      let(:fm_response) { { recordId: '147' } }
+      before do
+        data = instance_double(Soukyakukanri)
+        allow(Soukyakukanri).to receive(:new).and_return(data)
+        allow(data).to receive(:save).and_return(true)
+        allow(data).to receive(:record_id).and_return(fm_response[:recordId])
+      end
+      it 'FMのレコードIDを返す' do
+        post(api_v1_boseki_info_path, params:)
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['record_id']).to eq fm_response[:recordId]
+      end
+    end
+
+    context 'FMのレコード作成失敗時' do
+      before do
+        data = instance_double(Soukyakukanri)
+        allow(Soukyakukanri).to receive(:new).and_return(data)
+        allow(data).to receive(:save).and_raise(StandardError)
+      end
+      it 'status: 500 を返す (レコードIDは含まれない)' do
+        post(api_v1_boseki_info_path, params:)
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['status']).to eq 500
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:record_id) { 147 }
+    let(:params) do
+      {
+        data: {
+          cemetery_name: '本能寺',
+          record_id:
+        }
+      }
+    end
+    let(:data) { create(:soukyakukanri) }
+
+    context 'FMのレコード更新成功時' do
+      let(:fm_response) { { recordId: record_id } }
+
+      before do
+        allow(Soukyakukanri).to receive(:find).and_return(data)
+        allow(data).to receive(:update).and_return(true)
+        allow(data).to receive(:record_id).and_return(fm_response[:recordId])
+      end
+
+      it 'FMのレコードIDを返す' do
+        patch(api_v1_boseki_info_path, params:)
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['record_id']).to eq fm_response[:recordId]
+      end
+    end
+
+    context 'FMのレコード更新失敗時' do
+      before do
+        allow(Soukyakukanri).to receive(:find).and_raise(StandardError)
+      end
+
+      it 'status: 500 を返す (レコードIDは含まれない)' do
+        patch(api_v1_boseki_info_path, params:)
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['status']).to eq 500
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 作成したもの
- `Soukyakukanri`モデル
  - 複数のLPサイトからデータを保存するテーブルはコレだけという認識
- `boseki_info`コントローラー
  - `墓石ナビ`からのリクエストを受け付けるコントローラー
  - LP1つにつき1つのコントローラーを作った方がやりやすそう
  - LPごとに送られてくるキー名が統一されていないので、コントローラーでマッピングする 


## 問題（調査中）
`Soukyakukanri`モデルのカラム名に`.`ドットが入っているものをPOSTするとエラーになる。
`FmRest::APIError (FileMaker Data API responded with error 960: Parameter is invalid)`
`.`が入っていないものはPOSTできる。
FM側の設定で`.`を消してみても投稿できた。
**カラム名を変更してもらう必要があるかも**

