### PR TITLE
after_soukyakuモデルとコントローラー作成

### DIFF
--- a/app/controllers/api/v1/after_soukyakus_controller.rb
+++ b/app/controllers/api/v1/after_soukyakus_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Api::V1::AfterSoukyakusController < Api::V1::ApplicationController
+  def update
+    # curl -X PATCH -H 'Content-Type: application/json' -d '{"data": { "record_id": 245573, "open_introduction": "業者A,業者B,業者C"}}' "http://localhost:8000/api/v1/after_soukyaku"
+    # ページによって
+    data = AfterSoukyaku.find(after_soukyaku_params[:record_id])
+    data.update(add_contractor(data))
+    render json: { status: :ok, record_id: data.record_id }
+  rescue StandardError => e
+    Rails.logger.error e
+    render json: { status: 500, error: "Failure: #{e}" }
+  end
+
+  private
+
+  def after_soukyaku_params
+    params.require(:data).permit(:record_id, :open_introduction, :invitation, :participation, :nonparticipation)
+  end
+
+  # 改行を入れて元のデータと結合する
+  def add_contractor(data)
+    {
+      open_introduction: "#{data.open_introduction}\n#{after_soukyaku_params[:open_introduction].gsub(',', "\n")}" || data.open_introduction,
+      invitation: "#{data.invitation}\n#{after_soukyaku_params[:invitation].gsub(',', "\n")}" || data.invitatione,
+      participation: "#{data.participation}\n#{after_soukyaku_params[:participation].gsub(',', "\n")}" || data.participation,
+      nonparticipation: "#{data.nonparticipation}\n#{after_soukyaku_params[:nonparticipation].gsub(',', "\n")}" || data.nonparticipation
+    }
+  end
+end

--- a/app/controllers/api/v1/after_soukyakus_controller.rb
+++ b/app/controllers/api/v1/after_soukyakus_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::AfterSoukyakusController < Api::V1::ApplicationController
     # curl -X PATCH -H 'Content-Type: application/json' -d '{"data": { "record_id": 245573, "open_introduction": "業者A,業者B,業者C"}}' "http://localhost:8000/api/v1/after_soukyaku"
     # ページによって
     data = AfterSoukyaku.find(after_soukyaku_params[:record_id])
-    data.update(add_contractor(data))
+    data.update_contractor_fields(after_soukyaku_params)
     render json: { status: :ok, record_id: data.record_id }
   rescue StandardError => e
     Rails.logger.error e
@@ -16,15 +16,5 @@ class Api::V1::AfterSoukyakusController < Api::V1::ApplicationController
 
   def after_soukyaku_params
     params.require(:data).permit(:record_id, :open_introduction, :invitation, :participation, :nonparticipation)
-  end
-
-  # 改行を入れて元のデータと結合する
-  def add_contractor(data)
-    {
-      open_introduction: "#{data.open_introduction}\n#{after_soukyaku_params[:open_introduction]&.gsub(',', "\n")}" || data.open_introduction,
-      invitation: "#{data.invitation}\n#{after_soukyaku_params[:invitation]&.gsub(',', "\n")}" || data.invitatione,
-      participation: "#{data.participation}\n#{after_soukyaku_params[:participation]&.gsub(',', "\n")}" || data.participation,
-      nonparticipation: "#{data.nonparticipation}\n#{after_soukyaku_params[:nonparticipation]&.gsub(',', "\n")}" || data.nonparticipation
-    }
   end
 end

--- a/app/controllers/api/v1/after_soukyakus_controller.rb
+++ b/app/controllers/api/v1/after_soukyakus_controller.rb
@@ -21,10 +21,10 @@ class Api::V1::AfterSoukyakusController < Api::V1::ApplicationController
   # 改行を入れて元のデータと結合する
   def add_contractor(data)
     {
-      open_introduction: "#{data.open_introduction}\n#{after_soukyaku_params[:open_introduction].gsub(',', "\n")}" || data.open_introduction,
-      invitation: "#{data.invitation}\n#{after_soukyaku_params[:invitation].gsub(',', "\n")}" || data.invitatione,
-      participation: "#{data.participation}\n#{after_soukyaku_params[:participation].gsub(',', "\n")}" || data.participation,
-      nonparticipation: "#{data.nonparticipation}\n#{after_soukyaku_params[:nonparticipation].gsub(',', "\n")}" || data.nonparticipation
+      open_introduction: "#{data.open_introduction}\n#{after_soukyaku_params[:open_introduction]&.gsub(',', "\n")}" || data.open_introduction,
+      invitation: "#{data.invitation}\n#{after_soukyaku_params[:invitation]&.gsub(',', "\n")}" || data.invitatione,
+      participation: "#{data.participation}\n#{after_soukyaku_params[:participation]&.gsub(',', "\n")}" || data.participation,
+      nonparticipation: "#{data.nonparticipation}\n#{after_soukyaku_params[:nonparticipation]&.gsub(',', "\n")}" || data.nonparticipation
     }
   end
 end

--- a/app/controllers/api/v1/debug_controller.rb
+++ b/app/controllers/api/v1/debug_controller.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 #  TODO: Remove this controller before production
 class Api::V1::DebugController < Api::V1::ApplicationController
   def show_env
-    render json: { redis_host: ENV['REDIS_HOST'], redis_port: ENV['REDIS_PORT'], rails_env: ENV['RAILS_ENV'], redis_url: ENV['REDIS_URL'] }
+    render json: { redis_host: ENV.fetch('REDIS_HOST', nil), redis_port: ENV.fetch('REDIS_PORT', nil), rails_env: ENV.fetch('RAILS_ENV', nil), redis_url: ENV.fetch('REDIS_URL', nil) }
   end
 end

--- a/app/controllers/api/v1/gaiheki_infos_controller.rb
+++ b/app/controllers/api/v1/gaiheki_infos_controller.rb
@@ -36,7 +36,6 @@ class Api::V1::GaihekiInfosController < Api::V1::ApplicationController
                                  :area, :email)
   end
 
-  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
   def update_params(data)
     {
       prefecture: "#{data.prefecture}#{gaiheki_info_params[:addr]}" || data.prefecture, # 前画面で入力された市町村と結合

--- a/app/models/after_soukyaku.rb
+++ b/app/models/after_soukyaku.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AfterSoukyaku < FmRest::Layout('【カード】B_送客後ユーザー')
+  attributes(
+    open_introduction: 'オープン紹介業者',
+    invitation: '営業参加依募集業者',
+    participation: '営業参加成立業者',
+    nonparticipation: '営業参加不成立業者'
+  )
+end

--- a/app/models/after_soukyaku.rb
+++ b/app/models/after_soukyaku.rb
@@ -7,4 +7,21 @@ class AfterSoukyaku < FmRest::Layout('【カード】B_送客後ユーザー')
     participation: '営業参加成立業者',
     nonparticipation: '営業参加不成立業者'
   )
+
+  def update_contractor_fields(params)
+    update(
+      open_introduction: updated_field(open_introduction, params[:open_introduction]),
+      invitation: updated_field(invitation, params[:invitation]),
+      participation: updated_field(participation, params[:participation]),
+      nonparticipation: updated_field(nonparticipation, params[:nonparticipation])
+    )
+  end
+
+  private
+
+  def updated_field(original_data, new_data)
+    return original_data if new_data.nil?
+
+    "#{original_data}\n#{new_data.gsub(',', "\n")}"
+  end
 end

--- a/app/models/after_soukyaku.rb
+++ b/app/models/after_soukyaku.rb
@@ -21,6 +21,7 @@ class AfterSoukyaku < FmRest::Layout('【カード】B_送客後ユーザー')
 
   def updated_field(original_data, new_data)
     return original_data if new_data.nil?
+    return new_data.gsub(',', "\n") if original_data.empty?
 
     "#{original_data}\n#{new_data.gsub(',', "\n")}"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
       resource :reform_mitsumori, only: %i[create update]
       resource :kaitai_hikaku, only: %i[create]
       resource :reien_info, only: %i[create]
+      resource :after_soukyaku, only: %i[update]
       get 'debug/show_env', to: 'debug#show_env'
     end
   end

--- a/spec/factories/after_soukyaku.rb
+++ b/spec/factories/after_soukyaku.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :after_soukyaku do
+    name { '織田信長' }
+  end
+end

--- a/spec/models/after_soukyaku_spec.rb
+++ b/spec/models/after_soukyaku_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AfterSoukyaku, type: :model do
+  describe '#updated_fields' do
+    context '元からデータが入っている時' do
+      let(:original_data) { '元から入っている店' }
+      let(:new_data) { '新しく追加する店' }
+      let(:array) { '店1,店2,店3' }
+
+      let(:data) { build(:after_soukyaku) }
+
+      it '改行を挟んで追加される' do
+        expect(data.send(:updated_field, original_data, new_data)).to eq "#{original_data}\n#{new_data}"
+      end
+
+      it 'カンマ区切りは改行に変換される' do
+        expect(data.send(:updated_field, original_data, array)).to eq "#{original_data}\n店1\n店2\n店3"
+      end
+    end
+
+    context '元からデータが入っていない時' do
+      let(:original_data) { nil }
+      let(:new_data) { '新しく追加する店' }
+
+      let(:data) { build(:after_soukyaku) }
+
+      it '追加される' do
+        expect(data.send(:updated_field, original_data, new_data)).to eq new_data.to_s
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/after_soukyakus_spec.rb
+++ b/spec/requests/api/v1/after_soukyakus_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::AfterSoukyakus', type: :request do
+  describe '#update' do
+    let(:record_id) { 147 }
+    let(:params) do
+      {
+        data: {
+          open_introduction: 'hoge石材店',
+          record_id:
+        }
+      }
+    end
+    let(:data) { build(:after_soukyaku) }
+
+    context 'FMのレコード更新成功時' do
+      let(:fm_response) { { recordId: record_id } }
+
+      before do
+        allow(AfterSoukyaku).to receive(:find).and_return(data)
+        allow(data).to receive(:update_contractor_fields).and_return(true)
+        allow(data).to receive(:record_id).and_return(fm_response[:recordId])
+      end
+
+      it 'FMのレコードIDを返す' do
+        patch(api_v1_after_soukyaku_path, params:)
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['record_id']).to eq fm_response[:recordId]
+      end
+    end
+
+    context 'FMのレコード更新失敗時' do
+      before do
+        allow(AfterSoukyaku).to receive(:find).and_raise(StandardError)
+      end
+
+      it 'status: 500 を返す (レコードIDは含まれない)' do
+        patch(api_v1_after_soukyaku_path, params:)
+        expect(response).to have_http_status :ok
+        expect(JSON.parse(response.body)['status']).to eq 500
+      end
+    end
+  end
+end


### PR DESCRIPTION
![8b42e9a6151b4ecd78c2351b681b344c](https://user-images.githubusercontent.com/97825038/233586786-241dd0e1-c08a-4502-acbc-62d8990b28ee.gif)


既存のデータに
`{"data": { "record_id": 245573, "open_introduction": "業者A,業者B,業者C"}}`
のような形でパラメーターを送ると、改行入れて追加されます。
LPサイトの画面によってキー名は4種類あります。
