### PR TITLE
メディア名をFMの規則に沿った形に変更

### DIFF
--- a/app/controllers/api/v1/boseki_infos_controller.rb
+++ b/app/controllers/api/v1/boseki_infos_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::BosekiInfosController < Api::V1::ApplicationController
   # TODO: メディア名をメディア計算式の値に合わせる
-  MEDIA_NAME = '墓石ナビ'
+  MEDIA_NAME = '墓石'
 
   def create
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"name": "名前", "tel": "0120123456", "work_type": "墓じまいをしたい" }}' "http://localhost:8000/api/v1/boseki_info"

--- a/app/controllers/api/v1/boseki_soubas_controller.rb
+++ b/app/controllers/api/v1/boseki_soubas_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::BosekiSoubasController < Api::V1::ApplicationController
   # TODO: メディア名をメディア計算式の値に合わせる
-  MEDIA_NAME = '墓石相場net'
+  MEDIA_NAME = '墓石'
 
   def create
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"cf_ctype":"新たにお墓を建てたい","cf_gyard":"わかりません", "cf_name": "名前", "cf_phone": "0120123456", "cf_pref":"東京", "cf_address":"新宿区", "cf_email":"test.mail", "cf_misc" : "100万円"}}' "http://localhost:8000/api/v1/boseki_souba"

--- a/app/controllers/api/v1/bosui_ikkatsus_controller.rb
+++ b/app/controllers/api/v1/bosui_ikkatsus_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::BosuiIkkatsusController < Api::V1::ApplicationController
   # TODO: メディア名をメディア計算式の値に合わせる
-  MEDIA_NAME = '防水工事一括net'
+  MEDIA_NAME = '防水'
 
   def create
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"position": "ベランダの防水工事", "building_type": "一戸建て住宅", "addr": "愛知県名古屋市1-1-1", "name": "名前", "tel": "0120123456" }}' "http://localhost:8000/api/v1/bosui_ikkatsu"

--- a/app/controllers/api/v1/bosuis_controller.rb
+++ b/app/controllers/api/v1/bosuis_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::BosuisController < Api::V1::ApplicationController
   # TODO: メディア名をメディア計算式の値に合わせる
-  MEDIA_NAME = '防水工事セレクトナビ'
+  MEDIA_NAME = '防水'
 
   def create
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"addr": "愛知県名古屋市中区1-1-1", "name": "織田信長", "tel": "0120123456" }}' "http://localhost:8000/api/v1/bosui"

--- a/app/controllers/api/v1/gaiheki_ikkatsus_controller.rb
+++ b/app/controllers/api/v1/gaiheki_ikkatsus_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::GaihekiIkkatsusController < Api::V1::ApplicationController
   # TODO: メディア名をメディア計算式の値に合わせる
-  MEDIA_NAME = '外壁塗装一括net'
+  MEDIA_NAME = '外壁'
 
   def create
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"position": "工事種別", "building_type": "建物の種類", "addr": "長野県松本市1-1-1", "name": "名前", "tel": "012012345678" }}' "http://localhost:8000/api/v1/gaiheki_ikkatsu"

--- a/app/controllers/api/v1/gaiheki_infos_controller.rb
+++ b/app/controllers/api/v1/gaiheki_infos_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::GaihekiInfosController < Api::V1::ApplicationController
   # TODO: メディア名をメディア計算式の値に合わせる
-  MEDIA_NAME = '外壁塗装セレクトナビ'
+  MEDIA_NAME = '外壁'
 
   def create
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"addr": "青森県弘前市", "name": "名前", "tel": "0120123456", "chat": "LINE（ライン）"}}' "http://localhost:8000/api/v1/gaiheki_info"

--- a/app/controllers/api/v1/genjo_hikakus_controller.rb
+++ b/app/controllers/api/v1/genjo_hikakus_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::GenjoHikakusController < Api::V1::ApplicationController
   # TODO: メディア名をメディア計算式の値に合わせる
-  MEDIA_NAME = '原状回復比較ナビ'
+  MEDIA_NAME = '原状'
 
   def create
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"building_type": "店舗", "addr": "栃木県宇都宮市1-1-1", "area": "30", "mitsumori": "要望", "name": "名前", "kana": "namae", "tel": "0120123456", "mobile": "09012345678", "email": "fugahoge@yahoo.hoge"}}' "http://localhost:8000/api/v1/genjo_hikaku"

--- a/app/controllers/api/v1/kaitai_hikakus_controller.rb
+++ b/app/controllers/api/v1/kaitai_hikakus_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::KaitaiHikakusController < Api::V1::ApplicationController
   # TODO: メディア名をメディア計算式の値に合わせる
-  MEDIA_NAME = '解体工事見積もりnet'
+  MEDIA_NAME = '解体'
 
   def create
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"building_type": "一戸建て", "addr": "北海道札幌市中央区", "name": "徳川家康", "tel": "01201234567", "mitsumori": "要望" }}' "http://localhost:8000/api/v1/kaitai_hikaku"

--- a/app/controllers/api/v1/kaitaikoji_nets_controller.rb
+++ b/app/controllers/api/v1/kaitaikoji_nets_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::KaitaikojiNetsController < Api::V1::ApplicationController
   # TODO: メディア名をメディア計算式の値に合わせる
-  MEDIA_NAME = '解体工事比較ナビ'
+  MEDIA_NAME = '解体'
 
   def create
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"building_type": "アパート", "floor": "3", "area": "20", "addr": "東京都板橋区1-11-1", "name": "織田信長", "tel": "0120123456", "email": "hogehoge@hoge.com", "mitsumori": "aaaaa" }}' "http://localhost:8000/api/v1/kaitaikoji_net"

--- a/app/controllers/api/v1/reform_mitsumoris_controller.rb
+++ b/app/controllers/api/v1/reform_mitsumoris_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::ReformMitsumorisController < Api::V1::ApplicationController
   # TODO: メディア名をメディア計算式の値に合わせる
-  MEDIA_NAME = 'リフォーム比較プロ'
+  MEDIA_NAME = 'リフォーム'
 
   def create
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"addr": "東京都港区お台場1-2-3", "name": "山田太郎", "tel": "09012345678" }}' "http://localhost:8000/api/v1/reform_mitsumori"

--- a/app/controllers/api/v1/reien_infos_controller.rb
+++ b/app/controllers/api/v1/reien_infos_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V1::ReienInfosController < Api::V1::ApplicationController
   # TODO: メディア名をメディア計算式の値に合わせる
-  MEDIA_NAME = '霊園ナビ'
+  MEDIA_NAME = '霊園'
 
   def create
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"name": "名前", "tel": "0120123456" }}' "http://localhost:8000/api/v1/reien_info"

--- a/app/controllers/api/v1/yanekouji_infos_controller.rb
+++ b/app/controllers/api/v1/yanekouji_infos_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::YanekoujiInfosController < Api::V1::ApplicationController
-  MEDIA_NAME = '屋根見積りnet'
+  MEDIA_NAME = '屋根'
 
   def create
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"position": "工事種別", "addr": "東京都新宿区1-1-1", "name": "名前", "tel": "012012345678" }}' "http://localhost:8000/api/v1/yanekouji_info"

--- a/app/models/safta_soukyakukanri.rb
+++ b/app/models/safta_soukyakukanri.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class SaftaSoukyakukanri < FmRest::Layout('送客管理')
+class SaftaSoukyakukanri < FmRest::Layout('【カード】B_送客後ユーザー')
   self.fmrest_config = {
     host: ENV.fetch('FILEMAKER_HOST_SAFTA', nil),
     database: ENV.fetch('FILEMAKER_DB_SAFTA', nil),
     username: ENV.fetch('CLARIS_ID', nil),
-    password: ENV.fetch('CLARIS_PASS', nil)
+    password: ENV.fetch('CLARIS_PASS', nil),
   }
   attributes(
     media_name: 'F_外壁／防水',

--- a/app/models/sunlife_soukyakukanri.rb
+++ b/app/models/sunlife_soukyakukanri.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class SunlifeSoukyakukanri < FmRest::Layout('送客管理')
+class SunlifeSoukyakukanri < FmRest::Layout('【カード】B_送客後ユーザー')
   self.fmrest_config = {
     host: ENV.fetch('FILEMAKER_HOST_SUNLIFE', nil),
     database: ENV.fetch('FILEMAKER_DB_SUNLIFE', nil),
     username: ENV.fetch('CLARIS_ID', nil),
-    password: ENV.fetch('CLARIS_PASS', nil)
+    password: ENV.fetch('CLARIS_PASS', nil),
   }
   attributes(
     media_name: 'F_外壁／防水',


### PR DESCRIPTION
## 概要
メディア名が「外壁塗装セレクトナビ」のようにフルネームで入るようになっていたが、
実際にFMのデータベース内では「外壁」のようになっているので、実態に合った形に変更しました。

ここが既存のFMの規則に沿っていないと、FM上での業者とのリレーションが取れなくなるため。


`送客管理`→【`カード】B_送客後ユーザー`にレイアウトも変更しています（ケイタさんのご要望）