### PR TITLE
`kaitaikoji_net`新しいLPサイトに対応

### DIFF
--- a/app/controllers/api/v1/kaitaikoji_nets_controller.rb
+++ b/app/controllers/api/v1/kaitaikoji_nets_controller.rb
@@ -5,17 +5,12 @@ class Api::V1::KaitaikojiNetsController < Api::V1::ApplicationController
   MEDIA_NAME = '解体'
 
   def create
-    # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"building_type": "アパート", "floor": "3", "area": "20", "addr": "東京都板橋区1-11-1", "name": "織田信長", "tel": "0120123456", "email": "hogehoge@hoge.com", "mitsumori": "aaaaa" }}' "http://localhost:8000/api/v1/kaitaikoji_net"
+    # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"addr": "愛知県名古屋市中区1-1-1", "name": "織田信長", "tel": "0120123456" }}' "http://localhost:8000/api/v1/kaitaikoji_net"
     data = SaftaSoukyakukanri.new(
       media_name: MEDIA_NAME,
-      building_type: kaitaikoji_net_params[:building_type],
-      floor: kaitaikoji_net_params[:floor],
-      area: kaitaikoji_net_params[:area],
       prefecture: kaitaikoji_net_params[:addr],
       name: kaitaikoji_net_params[:name],
-      tel1: kaitaikoji_net_params[:tel],
-      email: kaitaikoji_net_params[:email],
-      customer_request: kaitaikoji_net_params[:mitsumori]
+      tel1: kaitaikoji_net_params[:tel]
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す
@@ -24,10 +19,30 @@ class Api::V1::KaitaikojiNetsController < Api::V1::ApplicationController
     render json: { status: 500, error: "Failure: #{e}" }
   end
 
+  def update
+    # curl -X PATCH -H 'Content-Type: application/json' -d '{"data": {"record_id": "245586", "building_type": "マンション" }}' "http://localhost:8000/api/v1/kaitaikoji_net"
+    # ページ遷移するごとにキー名が変わっていきます、bilding_type, position, area, email, mitsumori
+    data = SaftaSoukyakukanri.find(kaitaikoji_net_params[:record_id])
+    data.update(update_params(data))
+    render json: { status: :ok, record_id: data.record_id }
+  rescue StandardError => e
+    Rails.logger.error e
+    render json: { status: 500, error: "Failure: #{e}" }
+  end
+
   private
 
   def kaitaikoji_net_params
-    params.require(:data).permit(:record_id, :building_type, :floor, :area, :addr, :name, :tel, :email,
-                                 :mitsumori)
+    params.require(:data).permit(:record_id, :addr, :name, :tel, :building_type, :position, :area, :email, :mitsumori)
+  end
+
+  def update_params(data)
+    {
+      building_type: kaitaikoji_net_params[:building_type] || data.building_type,
+      construction_type: kaitaikoji_net_params[:position] || data.construction_type,
+      area: kaitaikoji_net_params[:area] || data.area,
+      email: kaitaikoji_net_params[:email] || data.email,
+      customer_request: kaitaikoji_net_params[:mitsumori] || data.customer_request
+    }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
       resource :bosui_ikkatsu, only: %i[create update]
       resource :gaiheki_ikkatsu, only: %i[create update]
       resource :yanekouji_info, only: %i[create update]
-      resource :kaitaikoji_net, only: %i[create]
+      resource :kaitaikoji_net, only: %i[create update]
       resource :boseki_souba, only: %i[create]
       resource :genjo_hikaku, only: %i[create update]
       resource :reform_mitsumori, only: %i[create update]


### PR DESCRIPTION
今までこちらのサイト仕様で作っていましたが→ https://kaitaikoji.net/form/
いつの間にかリダイレクトされてこちらのサイトに変更されていたので→ https://kaitaikoji.net/lp/kaitaikoji/index.html
コントローラーを新しいサイトに対応させるため、作り直しました。

![Uploading スクリーンショット 2023-06-09 23.37.58.png…]()

