### PR TITLE
「見積もり依頼日」を保存するように

### DIFF
--- a/app/controllers/api/v1/boseki_infos_controller.rb
+++ b/app/controllers/api/v1/boseki_infos_controller.rb
@@ -10,7 +10,8 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
       media_name: MEDIA_NAME,
       name: boseki_info_params[:name],
       tel1: boseki_info_params[:tel],
-      work_type: boseki_info_params[:work_type]
+      work_type: boseki_info_params[:work_type],
+      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/boseki_soubas_controller.rb
+++ b/app/controllers/api/v1/boseki_soubas_controller.rb
@@ -14,7 +14,8 @@ class Api::V1::BosekiSoubasController < Api::V1::ApplicationController
       tel1: boseki_souba_params[:cf_phone],
       cemetery_addr: "#{boseki_souba_params[:cf_pref]} #{boseki_souba_params[:cf_address]}",
       email: boseki_souba_params[:cf_email],
-      customer_request: boseki_souba_params[:cf_misc]
+      customer_request: boseki_souba_params[:cf_misc],
+      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/bosui_ikkatsus_controller.rb
+++ b/app/controllers/api/v1/bosui_ikkatsus_controller.rb
@@ -12,7 +12,8 @@ class Api::V1::BosuiIkkatsusController < Api::V1::ApplicationController
       building_type: bosui_ikkatsu_params[:building_type],
       prefecture: bosui_ikkatsu_params[:addr],
       name: bosui_ikkatsu_params[:name],
-      tel1: bosui_ikkatsu_params[:tel]
+      tel1: bosui_ikkatsu_params[:tel],
+      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/bosuis_controller.rb
+++ b/app/controllers/api/v1/bosuis_controller.rb
@@ -10,7 +10,8 @@ class Api::V1::BosuisController < Api::V1::ApplicationController
       media_name: MEDIA_NAME,
       prefecture: bosui_params[:addr],
       name: bosui_params[:name],
-      tel1: bosui_params[:tel]
+      tel1: bosui_params[:tel],
+      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/gaiheki_ikkatsus_controller.rb
+++ b/app/controllers/api/v1/gaiheki_ikkatsus_controller.rb
@@ -10,7 +10,8 @@ class Api::V1::GaihekiIkkatsusController < Api::V1::ApplicationController
       media_name: MEDIA_NAME,
       prefecture: gaiheki_ikkatsu_params[:addr],
       name: gaiheki_ikkatsu_params[:name],
-      tel1: gaiheki_ikkatsu_params[:tel]
+      tel1: gaiheki_ikkatsu_params[:tel],
+      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/gaiheki_infos_controller.rb
+++ b/app/controllers/api/v1/gaiheki_infos_controller.rb
@@ -11,7 +11,8 @@ class Api::V1::GaihekiInfosController < Api::V1::ApplicationController
       prefecture: gaiheki_info_params[:addr],
       name: gaiheki_info_params[:name],
       tel1: gaiheki_info_params[:tel],
-      chat: gaiheki_info_params[:chat]
+      chat: gaiheki_info_params[:chat],
+      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/genjo_hikakus_controller.rb
+++ b/app/controllers/api/v1/genjo_hikakus_controller.rb
@@ -16,7 +16,8 @@ class Api::V1::GenjoHikakusController < Api::V1::ApplicationController
       kana: genjo_hikaku_params[:kana],
       tel1: genjo_hikaku_params[:tel],
       tel2: genjo_hikaku_params[:mobile],
-      email: genjo_hikaku_params[:email]
+      email: genjo_hikaku_params[:email],
+      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/kaitai_hikakus_controller.rb
+++ b/app/controllers/api/v1/kaitai_hikakus_controller.rb
@@ -12,7 +12,8 @@ class Api::V1::KaitaiHikakusController < Api::V1::ApplicationController
       prefecture: kaitai_hikaku_params[:addr],
       name: kaitai_hikaku_params[:name],
       tel1: kaitai_hikaku_params[:tel],
-      customer_request: kaitai_hikaku_params[:mitsumori]
+      customer_request: kaitai_hikaku_params[:mitsumori],
+      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/kaitaikoji_nets_controller.rb
+++ b/app/controllers/api/v1/kaitaikoji_nets_controller.rb
@@ -10,7 +10,8 @@ class Api::V1::KaitaikojiNetsController < Api::V1::ApplicationController
       media_name: MEDIA_NAME,
       prefecture: kaitaikoji_net_params[:addr],
       name: kaitaikoji_net_params[:name],
-      tel1: kaitaikoji_net_params[:tel]
+      tel1: kaitaikoji_net_params[:tel],
+      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/kaitaikoji_nets_controller.rb
+++ b/app/controllers/api/v1/kaitaikoji_nets_controller.rb
@@ -5,17 +5,12 @@ class Api::V1::KaitaikojiNetsController < Api::V1::ApplicationController
   MEDIA_NAME = '解体'
 
   def create
-    # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"building_type": "アパート", "floor": "3", "area": "20", "addr": "東京都板橋区1-11-1", "name": "織田信長", "tel": "0120123456", "email": "hogehoge@hoge.com", "mitsumori": "aaaaa" }}' "http://localhost:8000/api/v1/kaitaikoji_net"
+    # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"addr": "愛知県名古屋市中区1-1-1", "name": "織田信長", "tel": "0120123456" }}' "http://localhost:8000/api/v1/kaitaikoji_net"
     data = SaftaSoukyakukanri.new(
       media_name: MEDIA_NAME,
-      building_type: kaitaikoji_net_params[:building_type],
-      floor: kaitaikoji_net_params[:floor],
-      area: kaitaikoji_net_params[:area],
       prefecture: kaitaikoji_net_params[:addr],
       name: kaitaikoji_net_params[:name],
-      tel1: kaitaikoji_net_params[:tel],
-      email: kaitaikoji_net_params[:email],
-      customer_request: kaitaikoji_net_params[:mitsumori]
+      tel1: kaitaikoji_net_params[:tel]
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す
@@ -24,10 +19,30 @@ class Api::V1::KaitaikojiNetsController < Api::V1::ApplicationController
     render json: { status: 500, error: "Failure: #{e}" }
   end
 
+  def update
+    # curl -X PATCH -H 'Content-Type: application/json' -d '{"data": {"record_id": "245586", "building_type": "マンション" }}' "http://localhost:8000/api/v1/kaitaikoji_net"
+    # ページ遷移するごとにキー名が変わっていきます、bilding_type, position, area, email, mitsumori
+    data = SaftaSoukyakukanri.find(kaitaikoji_net_params[:record_id])
+    data.update(update_params(data))
+    render json: { status: :ok, record_id: data.record_id }
+  rescue StandardError => e
+    Rails.logger.error e
+    render json: { status: 500, error: "Failure: #{e}" }
+  end
+
   private
 
   def kaitaikoji_net_params
-    params.require(:data).permit(:record_id, :building_type, :floor, :area, :addr, :name, :tel, :email,
-                                 :mitsumori)
+    params.require(:data).permit(:record_id, :addr, :name, :tel, :building_type, :position, :area, :email, :mitsumori)
+  end
+
+  def update_params(data)
+    {
+      building_type: kaitaikoji_net_params[:building_type] || data.building_type,
+      construction_type: kaitaikoji_net_params[:position] || data.construction_type,
+      area: kaitaikoji_net_params[:area] || data.area,
+      email: kaitaikoji_net_params[:email] || data.email,
+      customer_request: kaitaikoji_net_params[:mitsumori] || data.customer_request
+    }
   end
 end

--- a/app/controllers/api/v1/reform_mitsumoris_controller.rb
+++ b/app/controllers/api/v1/reform_mitsumoris_controller.rb
@@ -10,7 +10,8 @@ class Api::V1::ReformMitsumorisController < Api::V1::ApplicationController
       media_name: MEDIA_NAME,
       prefecture: reform_mitsumori_params[:addr],
       name: reform_mitsumori_params[:name],
-      tel1: reform_mitsumori_params[:tel]
+      tel1: reform_mitsumori_params[:tel],
+      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/reien_infos_controller.rb
+++ b/app/controllers/api/v1/reien_infos_controller.rb
@@ -9,7 +9,8 @@ class Api::V1::ReienInfosController < Api::V1::ApplicationController
     data = SaftaSoukyakukanri.new(
       media_name: MEDIA_NAME,
       name: reien_info_params[:name],
-      tel1: reien_info_params[:tel]
+      tel1: reien_info_params[:tel],
+      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/yanekouji_infos_controller.rb
+++ b/app/controllers/api/v1/yanekouji_infos_controller.rb
@@ -10,7 +10,8 @@ class Api::V1::YanekoujiInfosController < Api::V1::ApplicationController
       construction_type: yanekouji_info_params[:position],
       prefecture: yanekouji_info_params[:addr],
       name: yanekouji_info_params[:name],
-      tel1: yanekouji_info_params[:tel]
+      tel1: yanekouji_info_params[:tel],
+      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/models/safta_soukyakukanri.rb
+++ b/app/models/safta_soukyakukanri.rb
@@ -28,6 +28,7 @@ class SaftaSoukyakukanri < FmRest::Layout('【カード】B_送客後ユーザ�
     cemetery_addr: '墓所住所',
     tel2: 'L_電話番号2',
     kana: 'I_フリガナ',
-    chat: 'チャット'
+    chat: 'チャット',
+    estimated_date: 'A_見積依頼日'
   )
 end

--- a/app/models/sunlife_soukyakukanri.rb
+++ b/app/models/sunlife_soukyakukanri.rb
@@ -28,6 +28,7 @@ class SunlifeSoukyakukanri < FmRest::Layout('【カード】B_送客後ユーザ
     cemetery_addr: '墓所住所',
     tel2: 'L_電話番号2',
     kana: 'I_フリガナ',
-    chat: 'チャット'
+    chat: 'チャット',
+    estimated_date: 'A_見積依頼日'
   )
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ module FmApiBridgeManager
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
       resource :bosui_ikkatsu, only: %i[create update]
       resource :gaiheki_ikkatsu, only: %i[create update]
       resource :yanekouji_info, only: %i[create update]
-      resource :kaitaikoji_net, only: %i[create]
+      resource :kaitaikoji_net, only: %i[create update]
       resource :boseki_souba, only: %i[create]
       resource :genjo_hikaku, only: %i[create update]
       resource :reform_mitsumori, only: %i[create update]


### PR DESCRIPTION
## 概要
FMフィールド「A_見積依頼日」に保存時点での日付を保存できるようにしました。

## タイムゾーンの変更
`Tokyo`に変更してあります

## Filemaker API の Date 形式について
`mm/dd/YYYY`形式でリクエストしないと FM上の Date形式のバリデーションに引っかかるようです。
FM上での表示は`YYYY/mm/dd`に変換されています

<img width="537" alt="スクリーンショット 2023-06-10 11 36 51" src="https://github.com/YudaiNoda3576/FMAPIBridgeManager/assets/97825038/ab92c48f-43d0-4a92-86c8-afa581611829">
