### PR TITLE
見積日付の不具合修正

### DIFF
--- a/app/controllers/api/v1/boseki_infos_controller.rb
+++ b/app/controllers/api/v1/boseki_infos_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
       name: boseki_info_params[:name],
       tel1: boseki_info_params[:tel],
       work_type: boseki_info_params[:work_type],
-      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
+      estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/boseki_soubas_controller.rb
+++ b/app/controllers/api/v1/boseki_soubas_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::BosekiSoubasController < Api::V1::ApplicationController
       cemetery_addr: "#{boseki_souba_params[:cf_pref]} #{boseki_souba_params[:cf_address]}",
       email: boseki_souba_params[:cf_email],
       customer_request: boseki_souba_params[:cf_misc],
-      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
+      estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/bosui_ikkatsus_controller.rb
+++ b/app/controllers/api/v1/bosui_ikkatsus_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::BosuiIkkatsusController < Api::V1::ApplicationController
       prefecture: bosui_ikkatsu_params[:addr],
       name: bosui_ikkatsu_params[:name],
       tel1: bosui_ikkatsu_params[:tel],
-      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
+      estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/bosuis_controller.rb
+++ b/app/controllers/api/v1/bosuis_controller.rb
@@ -5,13 +5,13 @@ class Api::V1::BosuisController < Api::V1::ApplicationController
   MEDIA_NAME = '防水'
 
   def create
-    # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"addr": "愛知県名古屋市中区1-1-1", "name": "織田信長", "tel": "0120123456" }}' "http://localhost:8000/api/v1/bosui"
+    # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"addr": "愛知県名古屋市中区1-1-1", "name": "織田信長", "tel": "0120123456" }}' "http://a:a@localhost:8000/api/v1/bosui"
     data = SaftaSoukyakukanri.new(
       media_name: MEDIA_NAME,
       prefecture: bosui_params[:addr],
       name: bosui_params[:name],
       tel1: bosui_params[:tel],
-      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
+      estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/gaiheki_ikkatsus_controller.rb
+++ b/app/controllers/api/v1/gaiheki_ikkatsus_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::GaihekiIkkatsusController < Api::V1::ApplicationController
       prefecture: gaiheki_ikkatsu_params[:addr],
       name: gaiheki_ikkatsu_params[:name],
       tel1: gaiheki_ikkatsu_params[:tel],
-      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
+      estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/gaiheki_infos_controller.rb
+++ b/app/controllers/api/v1/gaiheki_infos_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::GaihekiInfosController < Api::V1::ApplicationController
       name: gaiheki_info_params[:name],
       tel1: gaiheki_info_params[:tel],
       chat: gaiheki_info_params[:chat],
-      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
+      estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/genjo_hikakus_controller.rb
+++ b/app/controllers/api/v1/genjo_hikakus_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::GenjoHikakusController < Api::V1::ApplicationController
       tel1: genjo_hikaku_params[:tel],
       tel2: genjo_hikaku_params[:mobile],
       email: genjo_hikaku_params[:email],
-      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
+      estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/kaitai_hikakus_controller.rb
+++ b/app/controllers/api/v1/kaitai_hikakus_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::KaitaiHikakusController < Api::V1::ApplicationController
       name: kaitai_hikaku_params[:name],
       tel1: kaitai_hikaku_params[:tel],
       customer_request: kaitai_hikaku_params[:mitsumori],
-      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
+      estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/kaitaikoji_nets_controller.rb
+++ b/app/controllers/api/v1/kaitaikoji_nets_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::KaitaikojiNetsController < Api::V1::ApplicationController
       prefecture: kaitaikoji_net_params[:addr],
       name: kaitaikoji_net_params[:name],
       tel1: kaitaikoji_net_params[:tel],
-      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
+      estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/reform_mitsumoris_controller.rb
+++ b/app/controllers/api/v1/reform_mitsumoris_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::ReformMitsumorisController < Api::V1::ApplicationController
       prefecture: reform_mitsumori_params[:addr],
       name: reform_mitsumori_params[:name],
       tel1: reform_mitsumori_params[:tel],
-      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
+      estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/reien_infos_controller.rb
+++ b/app/controllers/api/v1/reien_infos_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::ReienInfosController < Api::V1::ApplicationController
       media_name: MEDIA_NAME,
       name: reien_info_params[:name],
       tel1: reien_info_params[:tel],
-      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
+      estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す

--- a/app/controllers/api/v1/yanekouji_infos_controller.rb
+++ b/app/controllers/api/v1/yanekouji_infos_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::YanekoujiInfosController < Api::V1::ApplicationController
       prefecture: yanekouji_info_params[:addr],
       name: yanekouji_info_params[:name],
       tel1: yanekouji_info_params[:tel],
-      estimated_date: Time.zone.today.strftime("%m/%y/%Y")
+      estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
     render json: { status: :ok, record_id: data.record_id } # Filemaker の record_id を返す


### PR DESCRIPTION
## 不具合
`2023/06/11`に保存したにもかかわらず、FMに保存された見積もり日が`2023/06/23`になってしまっていた。


## 原因と対応
日付の表記指定が`%m/%y/%Y`になっていたため。
`%m/%d/%Y`に修正しました。