### PR TITLE
大規模修繕`mitsumori`を忘れていた

### DIFF
--- a/app/controllers/api/v1/boseki_infos_controller.rb
+++ b/app/controllers/api/v1/boseki_infos_controller.rb
@@ -12,6 +12,7 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
       tel1: boseki_info_params[:tel],
       work_type: boseki_info_params[:work_type],
       cemetery_name: boseki_info_params[:cemetery_name],
+      chat: boseki_info_params[:chat],
       estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
@@ -36,7 +37,7 @@ class Api::V1::BosekiInfosController < Api::V1::ApplicationController
 
   def boseki_info_params
     params.require(:data).permit(:record_id, :name, :tel, :work_type, :cemetery_name, :cemetery_addr, :addr, :area, :work_date,
-                                 :mitsumori, :email)
+                                 :mitsumori, :email, :chat)
   end
 
   def update_params(data)

--- a/app/controllers/api/v1/bosui_larges_controller.rb
+++ b/app/controllers/api/v1/bosui_larges_controller.rb
@@ -18,6 +18,7 @@ class Api::V1::BosuiLargesController < Api::V1::ApplicationController
       tel1: bosui_large_params[:tel1],
       tel2: bosui_large_params[:tel2],
       email: bosui_large_params[:email],
+      chat: bosui_large_params[:chat],
       estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
@@ -30,6 +31,6 @@ class Api::V1::BosuiLargesController < Api::V1::ApplicationController
   private
 
   def bosui_large_params
-    params.require(:data).permit(:record_id, :addr, :name, :building_type, :position, :area, :email, :kana, :tel1, :tel2, :mitsumori)
+    params.require(:data).permit(:record_id, :addr, :name, :building_type, :position, :area, :email, :kana, :tel1, :tel2, :mitsumori, :chat)
   end
 end

--- a/app/controllers/api/v1/bosui_larges_controller.rb
+++ b/app/controllers/api/v1/bosui_larges_controller.rb
@@ -12,6 +12,7 @@ class Api::V1::BosuiLargesController < Api::V1::ApplicationController
       construction_type: bosui_large_params[:position],
       area: bosui_large_params[:area],
       prefecture: bosui_large_params[:addr],
+      customer_request: bosui_large_params[:mitsumori],
       name: bosui_large_params[:name],
       kana: bosui_large_params[:kana],
       tel1: bosui_large_params[:tel1],
@@ -29,6 +30,6 @@ class Api::V1::BosuiLargesController < Api::V1::ApplicationController
   private
 
   def bosui_large_params
-    params.require(:data).permit(:record_id, :addr, :name, :building_type, :position, :area, :email, :kana, :tel1, :tel2)
+    params.require(:data).permit(:record_id, :addr, :name, :building_type, :position, :area, :email, :kana, :tel1, :tel2, :mitsumori)
   end
 end


### PR DESCRIPTION
## 依頼
```
テストを行った際に気付いたのですが、流入元（問い合わせフォーム先）の区別が出来るように
墓石ナビゲーションからの問い合わせの場合には【ナビゲーション】
大規模修繕セレクトナビからの問い合わせの場合には【大規模修繕】
とそれぞれ「チャット」というFMのフィールドに表記されるようにご対応いただけますでしょうか？

度々、後追いでの依頼となり申し訳有りません。。。
```

## 大規模修繕
- `mitsumori`が抜けていたので追加
- `チャット`フィールドを追加。「大規模修繕」と入れる（文字列はLPサイトから渡されます。）

## 墓石ナビゲーション
- `チャット`フィールドを追加。「ナビゲーション」と入れる（文字列はLPサイトから渡されます。）


