### PR TITLE
保存先のフィールド名を`墓石名`→`霊園名`に変更

### DIFF
--- a/app/models/safta_soukyakukanri.rb
+++ b/app/models/safta_soukyakukanri.rb
@@ -24,7 +24,7 @@ class SaftaSoukyakukanri < FmRest::Layout('【カード】B_送客後ユーザ�
     budget: '予算',
     work_type: '施工内容',
     building_age: '建物の築年数',
-    cemetery_name: '墓石名',
+    cemetery_name: '霊園名',
     cemetery_addr: '墓所住所',
     tel2: 'L_電話番号2',
     kana: 'I_フリガナ',


### PR DESCRIPTION
問い合わせあったので変更しました！
```
現在の繋ぎ込みでは「墓石名」というフィールドを指定しているものを「霊園名」というフィールドに変更をしたいです。
変更いただきたいサイトは２つございます。

①墓石ナビ
対象の設問：霊園名（寺院名）をご入力ください
https://www.chatwork.com/#!rid307769015-1692772625173991424メッセージリンク
②墓石ナビゲーション
対象の設問：霊園/寺院名
https://www.chatwork.com/#!rid307769015-1721411068120551424メッセージリンク
```

<img width="835" alt="スクリーンショット 2023-07-23 20 18 29" src="https://github.com/YudaiNoda3576/FMAPIBridgeManager/assets/97825038/ee249ae8-4b41-44cb-85f6-e9e60e52c960">

