### PR TITLE
外壁に項目追加

### DIFF
--- a/app/controllers/api/v1/gaiheki_infos_controller.rb
+++ b/app/controllers/api/v1/gaiheki_infos_controller.rb
@@ -5,13 +5,14 @@ class Api::V1::GaihekiInfosController < Api::V1::ApplicationController
   MEDIA_NAME = '外壁'
 
   def create
-    # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"addr": "青森県弘前市", "name": "名前", "tel": "0120123456", "chat": "LINE（ライン）"}}' "http://localhost:8000/api/v1/gaiheki_info"
+    # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"addr": "青森県弘前市", "name": "名前", "tel": "0120123456", "incentive": "問い合わせのきっかけ", "chat": "LINE（ライン）"}}' "http://localhost:8000/api/v1/gaiheki_info"
     data = SaftaSoukyakukanri.new(
       media_name: MEDIA_NAME,
       prefecture: gaiheki_info_params[:addr],
       name: gaiheki_info_params[:name],
       tel1: gaiheki_info_params[:tel],
       chat: gaiheki_info_params[:chat],
+      incentive: gaiheki_info_params[:incentive],
       estimated_date: Time.zone.today.strftime("%m/%d/%Y")
     )
     data.save
@@ -36,7 +37,7 @@ class Api::V1::GaihekiInfosController < Api::V1::ApplicationController
 
   def gaiheki_info_params
     params.require(:data).permit(:record_id, :addr, :name, :tel, :chat, :building_type, :position, :work_date, :company, :mitsumori,
-                                 :area, :email)
+                                 :area, :email, :incentive)
   end
 
   def update_params(data)

--- a/app/models/safta_soukyakukanri.rb
+++ b/app/models/safta_soukyakukanri.rb
@@ -29,6 +29,7 @@ class SaftaSoukyakukanri < FmRest::Layout('【カード】B_送客後ユーザ�
     tel2: 'L_電話番号2',
     kana: 'I_フリガナ',
     chat: 'チャット',
-    estimated_date: 'A_見積依頼日'
+    estimated_date: 'A_見積依頼日',
+    incentive: 'お問い合わせのきっかけ'
   )
 end

--- a/app/models/sunlife_soukyakukanri.rb
+++ b/app/models/sunlife_soukyakukanri.rb
@@ -24,7 +24,7 @@ class SunlifeSoukyakukanri < FmRest::Layout('【カード】B_送客後ユーザ
     budget: '予算',
     work_type: '施工内容',
     building_age: '建物の築年数',
-    cemetery_name: '墓石名',
+    cemetery_name: '霊園名',
     cemetery_addr: '墓所住所',
     tel2: 'L_電話番号2',
     kana: 'I_フリガナ',


### PR DESCRIPTION
## 概要
- サンライフの方も`墓石名`→`霊園名`に変更しました。
- 外壁塗装セレクトナビに「お問い合わせのきっかけ」項目を追加しました。


### FMのフィールド
本番環境に「お問い合わせのきっかけ」が作成されていたのでここに保存
<img width="905" alt="スクリーンショット 2023-07-30 16 54 11" src="https://github.com/YudaiNoda3576/FMAPIBridgeManager/assets/97825038/e045224f-509c-41e9-880c-de0ad24fbb0a">




### LPサイトの項目
name要素`user_addr`を拾って送信
<img width="1011" alt="スクリーンショット 2023-07-30 17 02 04" src="https://github.com/YudaiNoda3576/FMAPIBridgeManager/assets/97825038/cb168601-2c10-472e-8a98-16f9edbda088">

<img width="903" alt="スクリーンショット 2023-07-30 16 44 54" src="https://github.com/YudaiNoda3576/FMAPIBridgeManager/assets/97825038/16070bdc-d681-49a0-a5a6-291644d44b07">
