### PR TITLE
墓石相場ネット不具合修正

### DIFF
--- a/app/controllers/api/v1/boseki_soubas_controller.rb
+++ b/app/controllers/api/v1/boseki_soubas_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::BosekiSoubasController < Api::V1::ApplicationController
     # curl -X POST -H 'Content-Type: application/json' -d '{"data": {"cf_ctype":"新たにお墓を建てたい","cf_gyard":"わかりません", "cf_name": "名前", "cf_phone": "0120123456", "cf_pref":"東京", "cf_address":"新宿区", "cf_email":"test.mail", "cf_misc" : "100万円"}}' "http://localhost:8000/api/v1/boseki_souba"
     data = SunlifeSoukyakukanri.new(
       media_name: MEDIA_NAME,
-      construction_type: boseki_souba_params[:cf_ctype],
+      work_type: boseki_souba_params[:cf_ctype],
       cemetery_name: boseki_souba_params[:cf_gyard],
       name: boseki_souba_params[:cf_name],
       tel1: boseki_souba_params[:cf_phone],
@@ -45,7 +45,7 @@ class Api::V1::BosekiSoubasController < Api::V1::ApplicationController
       cemetery_addr: "#{data.cemetery_addr}#{boseki_souba_params[:cf_address] || boseki_souba_params[:cemetery_addr]}" || data.cemetery_addr,
       contact_time: boseki_souba_params[:cf_contact_time] || boseki_souba_params[:contact_time] || data.contact_time,
       contact_note: boseki_souba_params[:cf_contact_remark] || boseki_souba_params[:contact_remark] ||data.contact_note,
-      cf_email: boseki_souba_params[:cf_email] || boseki_souba_params[:email] || data.email,
+      email: boseki_souba_params[:cf_email] || boseki_souba_params[:email] || data.email,
       customer_request: boseki_souba_params[:cf_misc] || boseki_souba_params[:mitsumori] || data.customer_request,
       work_date: boseki_souba_params[:cf_ctype] || boseki_souba_params[:work_date] || data.work_date,
     }

--- a/app/controllers/api/v1/boseki_soubas_controller.rb
+++ b/app/controllers/api/v1/boseki_soubas_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::BosekiSoubasController < Api::V1::ApplicationController
       cemetery_name: boseki_souba_params[:cf_gyard],
       name: boseki_souba_params[:cf_name],
       tel1: boseki_souba_params[:cf_phone],
-      cemetery_addr: "#{boseki_souba_params[:cf_pref]}#{boseki_souba_params[:cf_address]}",
+      cemetery_addr: boseki_souba_params[:cf_pref],
       email: boseki_souba_params[:cf_email],
       customer_request: boseki_souba_params[:cf_misc],
       estimated_date: Time.zone.today.strftime("%m/%d/%Y")
@@ -42,7 +42,7 @@ class Api::V1::BosekiSoubasController < Api::V1::ApplicationController
 
   def update_params(data)
     {
-      prefecture: "#{data.prefecture}#{boseki_souba_params[:cf_address] || boseki_souba_params[:cemetery_addr]}" || data.prefecture,
+      cemetery_addr: "#{data.cemetery_addr}#{boseki_souba_params[:cf_address] || boseki_souba_params[:cemetery_addr]}" || data.cemetery_addr,
       contact_time: boseki_souba_params[:cf_contact_time] || boseki_souba_params[:contact_time] || data.contact_time,
       contact_note: boseki_souba_params[:cf_contact_remark] || boseki_souba_params[:contact_remark] ||data.contact_note,
       cf_email: boseki_souba_params[:cf_email] || boseki_souba_params[:email] || data.email,


### PR DESCRIPTION
## 問い合わせ内容
```
墓石相場netで3点、修正頂きたい内容がありましたのでご対応をお願いします。
①市区町村以降の住所の返り先
■対象フォーム

橋本　日向
2023年8月3日 14:20
https://boseki-souba.net/lp/?gclid=CjwKCAjw_aemBhBLEiwAT98FMpFsSkkMA0B7n1PojPt7AIDnvwzM7-P9igCKSkLfARTE_q6UV-9-oBoC8NAQAvD_BwE　（LP PC）

橋本　日向
2023年8月3日 14:20
https://boseki-souba.net/lp/sp/index.html?gclid=CjwKCAjw_aemBhBLEiwAT98FMiC6olDa38f0JHOl_LgOPXC-Nj04R5E5OnieH7o1XEevWb51U6NbVBoCcfMQAvD_BwE　（LPスマホ）
■フィールド
現在「E_都道府県」　→　変更「墓所住所」

最初のフォームで都道府県を選択した結果は「墓所住所」に入ってきますが
その後の市以降の住所の設問結果は「E_都道府県」に返っています。
②工事種別の回答結果の返り先
■対象フォーム
全て
■フィールド
現在「工事種別」　→　変更「施工内容」

非常にややこしくても申し訳ないのですが、最初のフォームで【工事種別】として回答を拾っている内容は
「施工内容」のフィールドに入ってくるようにしたいです。
③市以降の住所の重複
■対象フォーム

橋本　日向
2023年8月3日 14:20
https://boseki-souba.net/estimate.html

■フィールド
「墓所住所」

①と異なり、こちらのフォームから問合せた場合の住所は問題なく「墓所住所」に入ってきています。
ただし、市以降の住所の設問結果が二重で返されています。
【例】
『大阪府大阪市浪速区大阪市浪速区』『大阪府大阪市阿倍野区旭町1丁目1-17大阪市阿倍野区旭町1丁目1-17』

こちらの修正もお願いします。
```

## やったこと
- 住所の保存先を`墓所住所: cemetery_addr`に統一
- 住所と都道府県がLP内で既に結合されていたので、結合しないように
- `工事種別`→`施工内容`に変更
- email のキー名が間違っていたので修正